### PR TITLE
Tooltip's not working

### DIFF
--- a/lib/generators/on_the_spot/install/templates/on_the_spot.js
+++ b/lib/generators/on_the_spot/install/templates/on_the_spot.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
             load_url     = el.attr('data-loadurl');
 
         var options = {
-            tooltip: tooltip_text,
+            placeholder: tooltip_text,
             cancel: cancel_text,
             submit: ok_text,
             onerror: function (settings, original, xhr) {


### PR DESCRIPTION
jEditable was just showing their default tooltip text, turns out tooltip needs to be called placeholder in the options hash
