### PR TITLE
Allow field value to be evaluated as raw HTML

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -89,6 +89,7 @@ The `on_the_spot_edit` also accepts options:
 * `:url`: URL to post to if you don't want to use the standard routes
 * `:selected`: Text selected by default on edit (boolean, default is false)
 * `:callback`: The name of a javascript function that is called after form has been submitted
+* `:raw`: if set to true, evaluate the field value as raw HTML.
 
 
 For the texts: if a text is not specified, the default is taken from the `on_the_spot.en.yml` (or your current language).

--- a/lib/on_the_spot/controller_extension.rb
+++ b/lib/on_the_spot/controller_extension.rb
@@ -15,7 +15,8 @@ module OnTheSpot
           object = klass.camelize.constantize.find(id)
           if object.update_attributes(field => params[:value])
             if select_data.nil?
-              render :text => CGI::escapeHTML(object.send(field).to_s)
+              value = object.send(field).to_s
+              render :text => params[:raw] ? value : CGI::escapeHTML(value)
             else
               parsed_data = JSON.parse(select_data.gsub("'", '"'))
               render :text => parsed_data[object.send(field).to_s]

--- a/lib/on_the_spot/on_the_spot_helpers.rb
+++ b/lib/on_the_spot/on_the_spot_helpers.rb
@@ -36,10 +36,11 @@ module OnTheSpot
                              :url         => {:action => 'update_attribute_on_the_spot'}
                             )
 
+      options[:url].merge!(:raw => true) if options[:raw]
       update_url = url_for(options[:url])
-
-      field_value =  object.send(field.to_sym).to_s
-
+      
+      field_value = options[:raw] ? raw(object.send(field.to_sym)) : object.send(field.to_sym).to_s
+      
       html_options = { :id => "#{object.class.name.underscore}__#{field}__#{object.id}",
                        :class => 'on_the_spot_editing',
                        :'data-url' => update_url}
@@ -68,7 +69,7 @@ module OnTheSpot
         if options[:display_text]
           options[:display_text]
         elsif editable_type == :select && options[:loadurl].nil?
-          lookup_display_valuex(select_data, field_value)
+          lookup_display_value(select_data, field_value)
         else
           field_value
         end

--- a/spec/on_the_spot_spec.rb
+++ b/spec/on_the_spot_spec.rb
@@ -109,7 +109,7 @@ describe "OnTheSpot" do
             @result.should == "<span class=\"on_the_spot_editing\" data-cancel=\"cancel\" data-edittype=\"select\" data-loadurl=\"/load/data\" data-ok=\"ok\" data-tooltip=\"tooltip\" data-url=\"/bla\" id=\"r_spec/mocks/mock__content__123\">test</span>"
           end
 
-          it "usea the display-text preferrably" do
+          it "uses the display-text preferrably" do
             @result = @tester.on_the_spot_edit @dummy, :content, :type => :select, :loadurl => '/load/data', :display_text => 'ninja'
             @result.should == "<span class=\"on_the_spot_editing\" data-cancel=\"cancel\" data-edittype=\"select\" data-loadurl=\"/load/data\" data-ok=\"ok\" data-tooltip=\"tooltip\" data-url=\"/bla\" id=\"r_spec/mocks/mock__content__123\">ninja</span>"
           end
@@ -125,7 +125,18 @@ describe "OnTheSpot" do
           @result = @tester.on_the_spot_edit @dummy, :content, :url => {:action => 'update_it_otherwise' }
           @result.should == "<span class=\"on_the_spot_editing\" data-cancel=\"cancel\" data-ok=\"ok\" data-tooltip=\"tooltip\" data-url=\"/bla\" id=\"r_spec/mocks/mock__content__123\">test</span>"
         end
-
+      end
+      
+      context "with raw paramater" do
+        before(:each) do
+          @tester.should_receive(:url_for).with({:action => 'update_attribute_on_the_spot', :raw => true}).and_return('/bla?raw=true')
+        end
+        
+        it "supports raw html" do
+          @dummy.stub!(:content).and_return('<b>test</b>')
+          @result = @tester.on_the_spot_edit @dummy, :content, :raw => true
+          @result.should == "<span class=\"on_the_spot_editing\" data-cancel=\"cancel\" data-ok=\"ok\" data-tooltip=\"tooltip\" data-url=\"/bla?raw=true\" id=\"r_spec/mocks/mock__content__123\"><b>test</b></span>"
+        end
       end
     end
   end


### PR DESCRIPTION
I faced a situation where I wanted the inplaced field to be evaluated as raw html. I modified your gem to support this case.

Let me know if this is something that you would find useful.
