### PR TITLE
Make sure javascript_expansions config option exists

### DIFF
--- a/lib/on_the_spot.rb
+++ b/lib/on_the_spot.rb
@@ -5,7 +5,9 @@ module OnTheSpot
   class Engine < ::Rails::Engine
 
     config.before_initialize do
-      config.action_view.javascript_expansions[:on_the_spot] = %w(jquery.jeditable.mini.js on_the_spot_code)
+      if config.action_view.javascript_expansions
+        config.action_view.javascript_expansions[:on_the_spot] = %w(jquery.jeditable.mini.js on_the_spot_code)
+      end
     end
 
     # configure our plugin on boot. other extension points such


### PR DESCRIPTION
Provides compatibility for Rails 4.

javascript_expansions config option has been removed in Rails 4 (along with all old asset concat tags), so we have to check for its existence first, like jquery-rails does:
https://github.com/rails/jquery-rails/blob/master/lib/jquery/rails/railtie.rb
